### PR TITLE
Add compatibility for Composer 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "composer-plugin-api": "^1.1",
+        "composer-plugin-api": "^1.1|^2",
         "composer/composer": "*"
     },
     "autoload": {

--- a/src/DrupalAutoloadPlugin.php
+++ b/src/DrupalAutoloadPlugin.php
@@ -39,6 +39,20 @@ class DrupalAutoloadPlugin implements PluginInterface, EventSubscriberInterface 
   /**
    * {@inheritdoc}
    */
+  public function deactivate(Composer $composer, IOInterface $io) {
+    // Do nothing.
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function uninstall(Composer $composer, IOInterface $io) {
+    // Do nothing.
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public static function getSubscribedEvents() {
     return array(
       ScriptEvents::PRE_AUTOLOAD_DUMP =>


### PR DESCRIPTION
Adding compatibility seems to be straight forward:

- Allow the new version in the package requirements.
- Update the plugin to match new requirements from the [Composer
plugin interface](https://github.com/composer/composer/blob/master/src/Composer/Plugin/PluginInterface.php).

Two methods, `disable()` and `uninstall()`, have been added to the
interface so they are added. At the moment they do nothing.

Closes #3