### PR TITLE
Autoload test directories

### DIFF
--- a/src/DrupalAutoloadPlugin.php
+++ b/src/DrupalAutoloadPlugin.php
@@ -119,6 +119,11 @@ class DrupalAutoloadPlugin implements PluginInterface, EventSubscriberInterface 
 
     array_map(function ($directory) use ($base_dir, &$namespaces) {
       $this->addModuleToNamespaces($namespaces, $directory, $base_dir);
+
+      // If there are tests within the module, autoload them too.
+      if (file_exists($base_dir . $directory . '/tests/src')) {
+        $this->addModuleTestsToNamespaces($namespaces, $directory, $base_dir);
+      }
     }, $module_directories);
   }
 
@@ -135,6 +140,21 @@ class DrupalAutoloadPlugin implements PluginInterface, EventSubscriberInterface 
   public function addModuleToNamespaces(array &$namespaces, $directory, $base_dir) {
     $namespace = 'Drupal\\' . $directory . '\\';
     $namespaces[$namespace] = $base_dir . $directory . '/src';
+  }
+
+  /**
+   * Add module tests to namespaces.
+   *
+   * @param array $namespaces
+   *   The current namespaces array to add into.
+   * @param string $directory
+   *   The directory of the module.
+   * @param string $base_dir
+   *   The base directory to build from.
+   */
+  public function addModuleTestsToNamespaces(array &$namespaces, $directory, $base_dir) {
+    $namespace = 'Drupal\\Tests\\' . $directory . '\\';
+    $namespaces[$namespace] = $base_dir . $directory . '/tests/src';
   }
 
   /**


### PR DESCRIPTION
## Problem

I've been evaluating Phpactor recently whilst working on Drupal projects and found that I was getting a `There are no class name candidates` error when trying to create a new class.

After installing this plugin and dumping an updated autoloader, creating a class within a module's `src` directory worked, but it still couldn't generate a test class within the `tests/src` directory.

## Solution

Reviewing the autoload_psr4.php file, I could see that the module's `src` directory was being loaded correctly but the `tests/src` directory wasn't included.

After adding one manually to confirm it fixed the issue, I've created this PR that checks for a `tests/src` directory within each module and if one exists, adds it to the expected `Drupal\\Tests\\` namespace`.